### PR TITLE
Explicitly show scrollbar

### DIFF
--- a/templates/vue/src/components/Lightbox.vue
+++ b/templates/vue/src/components/Lightbox.vue
@@ -202,12 +202,12 @@ export default {
     box-shadow: 0 0 100px -40px #000;
     border-radius: 15px;
     scrollbar-color: rgba(0,0,0,.5) rgba(255,255,255,.5) ;
-    scrollbar-width: 7px;
+    scrollbar-width: auto;
     -ms-overflow-style:scrollbar;
 
     ::-webkit-scrollbar {
       -webkit-appearance: none;
-      width: 7px;
+      width: 12px;
     }
 
     ::-webkit-scrollbar-thumb {

--- a/templates/vue/src/components/Lightbox.vue
+++ b/templates/vue/src/components/Lightbox.vue
@@ -263,6 +263,9 @@ export default {
     background-color: black;
     box-shadow: 0 0 100px -40px #000;
     border-radius: 15px;
+    scrollbar-color: rgba(0,0,0,.5) rgba(255,255,255,.5) ;
+    scrollbar-width: 7px;
+    -ms-overflow-style:scrollbar;
 
     ::-webkit-scrollbar {
       -webkit-appearance: none;

--- a/templates/vue/src/components/Lightbox.vue
+++ b/templates/vue/src/components/Lightbox.vue
@@ -264,6 +264,21 @@ export default {
     box-shadow: 0 0 100px -40px #000;
     border-radius: 15px;
 
+    ::-webkit-scrollbar {
+      -webkit-appearance: none;
+      width: 7px;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      border-radius: 4px;
+      background-color: rgba(0,0,0,.5);
+      box-shadow: 0 0 1px rgba(255,255,255,.5);
+    }
+
+    ::-webkit-scrollbar-corner {
+      display: none;
+    }
+
     .media-wrapper {
       background: #000;
       outline: none;


### PR DESCRIPTION
Fix will force show a custom scrollbar for windows and mac

Fixing the issue to explicitly show for mac:
http://simurai.com/blog/2011/07/26/webkit-scrollbar

![image](https://user-images.githubusercontent.com/13321051/72394207-3c4abe80-36ea-11ea-8f28-5e90e3d7d94b.png)
