### PR TITLE
Improve algorithms for finding node parent & more

### DIFF
--- a/endpoints.php
+++ b/endpoints.php
@@ -563,11 +563,7 @@ function updateTapestryNode($request)
         }
 
         $tapestry = new Tapestry($postId);
-        $isValid = $tapestry->validateNode((object) $nodeData, $tapestry->getNodeParent($nodeMetaId));
-
-        if (!$isValid) {
-            throw new TapestryError('INVALID_NODE_TYPE');
-        }
+        $tapestry->validateNode((object) $nodeData, $tapestry->getNodeParent($nodeMetaId));
 
         $node = $tapestry->getNode($nodeMetaId);
         $node->set((object) $nodeData);

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -2071,11 +2071,32 @@ function tapestryTool(config){
      ****************************************************/
     
     function getParent(node) {
-        const links = tapestry.dataset.links;
-        const link = links.find(l => l.target == node.id || l.target.id == node.id);
-        return typeof link.source === "object" 
-            ? link.source 
-            : getNodeById(link.source);
+        if (tapestry.dataset.rootId === node.id) {
+            return null
+        }
+        const neighbourIds = getNeighbours(node.id)
+        if (!neighbourIds) {
+            return null
+        }
+        const tydeTypes = {
+            REGULAR: "Regular",
+            MODULE: "Module",
+            STAGE: "Stage",
+            QUESTION_SET: "Question set",
+        }
+        const neighbours = neighbourIds.map( id => getNodeById(id) )
+        switch (node.tydeType) {
+            case tydeTypes.MODULE:
+                return neighbours.find( n => n.tydeType === tydeTypes.REGULAR || !n.tydeType ) || neighbours[0]
+            case tydeTypes.STAGE:
+                return neighbours.find( n => n.tydeType === tydeTypes.MODULE ) || neighbours[0]
+            case tydeTypes.QUESTION_SET:
+                return neighbours.find( n => n.tydeType === tydeTypes.STAGE ) || neighbours[0]
+            default:
+                return neighbours.find( n => n.tydeType === tydeTypes.STAGE )
+                    || neighbours.find( n => n.mediaType === "accordion" && n.childOrdering && n.childOrdering.find( c => c.id === node.id) )
+                    || neighbours.find( n => n.mediaType !== "accordion" ) || neighbours[0]
+            }
     }
     
     // Set multiple attributes for an HTML element at once

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -604,7 +604,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(["getDirectChildren", "getDirectParents", "getNode"]),
+    ...mapGetters(["getDirectChildren", "getParent", "getNode"]),
     videoLabel() {
       const labels = {
         [tydeTypes.STAGE]: "Pre-Stage Video URL",
@@ -642,13 +642,9 @@ export default {
       return false
     },
     hasSubAccordion() {
-      const parents = this.getDirectParents(this.node.id)
-      if (parents && parents[0]) {
-        const parent = this.getNode(parents[0])
-        const children = this.getDirectChildren(this.node.id)
-        return parent.mediaType === "accordion" && children.length > 0
-      }
-      return false
+      const parent = this.getParent(this.node)
+      const children = this.getDirectChildren(this.node.id)
+      return parent && parent.mediaType === "accordion" && children.length
     },
     nodeType() {
       if (this.node.mediaFormat === "h5p") {

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -86,7 +86,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(["selectedNode", "tapestry", "getNode", "getDirectParents"]),
+    ...mapGetters(["selectedNode", "tapestry", "getNode", "getParent"]),
     showRootNodeButton: function() {
       return (
         this.tapestryLoaded &&
@@ -127,13 +127,12 @@ export default {
   },
   watch: {
     selectedNode() {
-      this.parentNode = this.getNode(this.getDirectParents(this.selectedNode)[0])
+      this.parentNode = this.getParent(this.selectedNode)
     },
   },
   async created() {
     const tapestryApi = new TapestryApi(wpPostId)
-    const response = await tapestryApi.getUserFavourites()
-    this.favourites = JSON.parse(response.data)
+    this.favourites = await tapestryApi.getUserFavourites()
   },
   mounted() {
     window.addEventListener("change-selected-node", this.changeSelectedNode)
@@ -207,7 +206,7 @@ export default {
     },
     editNode() {
       this.modalType = "edit-node"
-      this.parentNode = this.getNode(this.getDirectParents(this.selectedNode.id)[0])
+      this.parentNode = this.getParent(this.selectedNode)
       this.populatedNode = this.selectedNode
       this.$bvModal.show("node-modal-container")
     },

--- a/templates/vue/src/components/TapestryMedia.vue
+++ b/templates/vue/src/components/TapestryMedia.vue
@@ -127,7 +127,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(["getNode", "getDirectParents"]),
+    ...mapGetters(["getNode"]),
     node() {
       return this.getNode(this.nodeId)
     },

--- a/templates/vue/src/components/tyde/TydeStage.vue
+++ b/templates/vue/src/components/tyde/TydeStage.vue
@@ -90,19 +90,13 @@ export default {
     },
   },
   computed: {
-    ...mapGetters(["getNode", "getDirectChildren", "getDirectParents"]),
+    ...mapGetters(["getNode", "getDirectChildren"]),
     ...mapState(["selectedModuleId"]),
     done() {
       return this.topics.every(topic => topic.completed)
     },
     node() {
       return this.getNode(this.nodeId)
-    },
-    moduleId() {
-      const moduleIds = this.getDirectParents(this.nodeId).filter(
-        id => this.getNode(id).tydeType === tydeTypes.MODULE
-      )
-      return moduleIds[0]
     },
     nodeStyles() {
       return {

--- a/templates/vue/src/services/TapestryAPI.js
+++ b/templates/vue/src/services/TapestryAPI.js
@@ -194,7 +194,7 @@ export default class {
   async getUserFavourites() {
     const url = `${apiUrl}/users/favourites?post_id=${this.postId}`
     const response = await axios.get(url)
-    return response
+    return JSON.parse(response.data)
   }
 
   async updateUserFavourites(favourites) {

--- a/templates/vue/src/store/getters.js
+++ b/templates/vue/src/store/getters.js
@@ -1,7 +1,31 @@
-export function getParent(state) {
-  return id => {
-    const link = state.links.find(l => l.target == id || l.target.id == id)
-    return link ? link.source : null
+export function getParent(state, { getNode, getDirectParents, getDirectChildren}) {
+  return node => {
+    if (state.rootId === node.id) {
+      return null
+    }
+    const neighbourIds = getDirectParents(node.id).concat(getDirectChildren(node.id))
+    if (!neighbourIds) {
+      return null
+    }
+    const tydeTypes = {
+      REGULAR: "Regular",
+      MODULE: "Module",
+      STAGE: "Stage",
+      QUESTION_SET: "Question set",
+    }
+    const neighbours = neighbourIds.map( id => getNode(id) )
+    switch (node.tydeType) {
+      case tydeTypes.MODULE:
+        return neighbours.find( n => n.tydeType === tydeTypes.REGULAR || !n.tydeType ) || neighbours[0]
+      case tydeTypes.STAGE:
+        return neighbours.find( n => n.tydeType === tydeTypes.MODULE ) || neighbours[0]
+      case tydeTypes.QUESTION_SET:
+        return neighbours.find( n => n.tydeType === tydeTypes.STAGE ) || neighbours[0]
+      default:
+        return neighbours.find( n => n.tydeType === tydeTypes.STAGE )
+            || neighbours.find( n => n.mediaType === "accordion" && n.childOrdering && n.childOrdering.find( c => c.id === node.id) )
+            || neighbours.find( n => n.mediaType !== "accordion" ) || neighbours[0]
+    }
   }
 }
 

--- a/templates/vue/src/store/mutations.js
+++ b/templates/vue/src/store/mutations.js
@@ -125,19 +125,34 @@ export function updateTydeProgress(state, { parentId, isParentModule }) {
       : childProgress.reduce(reducer, 0) / childNodes.length
   if (!isParentModule) {
     // If node is stage, parent module must be updated as well
-    getParentIds(state, parentId).map(id =>
+    getStageParent(state, parentId).map(id =>
       updateTydeProgress(state, { parentId: id, isParentModule: true })
     )
   }
 }
 
-function getParentIds(state, nodeId) {
+function getStageParent(state, nodeId) {
   const links = state.links
-  return links
+  let neighbourIds = links
+    .filter(link => link.source.id === nodeId || link.target.id === nodeId)
+    .map(link => link.source.id === nodeId ? link.target.id : link.source.id)
+  if (!neighbourIds) {
+    neighbourIds = links
+      .filter(link => link.source === nodeId || link.target === nodeId)
+      .map(link => link.source === nodeId ? link.target : link.source)
+  }
+  if (neighbourIds.length) {
+    const neighbours = neighbourIds.map( id => state.nodes.find(node => node.id === id) )
+    const parent = neighbours.find( n => n.tydeType === tydeTypes.MODULE ) || neighbours[0]
+    return [...parent.id]
+  }
+  else {
+    return links
     .filter(link =>
       link.target.id == undefined ? link.target == nodeId : link.target.id == nodeId
     )
     .map(link => (link.source.id == undefined ? link.source : link.source.id))
+  }
 }
 
 // favourites

--- a/utilities/class.tapestry-errors.php
+++ b/utilities/class.tapestry-errors.php
@@ -22,6 +22,10 @@ class TapestryError extends Error
             'MESSAGE'   => 'PostID is invalid',
             'STATUS'    => ['status' => 404]
         ],
+        'INVALID_NODE_TYPE' => [
+            'MESSAGE'   => 'Node type is invalid',
+            'STATUS'    => ['status' => 406]
+        ],
         'INVALID_NODE_META_ID' => [
             'MESSAGE'   => 'NodeMetaId is invalid',
             'STATUS'    => ['status' => 404]


### PR DESCRIPTION
- Use a smarter algorithm for finding parent of a node
- Take into account the tydeType and child ordering when finding parents
- Update getParent algorithm everywhere
- Improve node type validation
- Remove obsolete code