### PR TITLE
1037 - Allow navigating tapestry by keyboard

### DIFF
--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -111,7 +111,6 @@ li p {
     color: #999;
     font-size: 1.2em;
     transition: all 0.2s ease;
-    outline: none;
 }
 
 .settings-button:hover {

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -123,7 +123,6 @@ li p {
 
 #tapestry-depth-slider {
     margin-top: 6px;
-    outline: none;
     background: #d3d3d3;
     height: 10px;
     opacity: 0.8;
@@ -131,6 +130,7 @@ li p {
     position: relative;
     margin: 0 32px;
 }
+
 
 #tapestry-depth-slider::before,
 #tapestry-depth-slider::after {

--- a/templates/vue/src/App.vue
+++ b/templates/vue/src/App.vue
@@ -132,10 +132,6 @@ html {
       }
     }
 
-    button:focus {
-      outline: none;
-    }
-
     .btn {
       &:disabled,
       &.disabled {

--- a/templates/vue/src/components/Lightbox/TapestryModal/ModalButton.vue
+++ b/templates/vue/src/components/Lightbox/TapestryModal/ModalButton.vue
@@ -2,6 +2,7 @@
   <button
     class="modal-button"
     :style="buttonStyles"
+    tabindex="0"
     @click="$emit('clicked')"
     @mouseover="hovering = true"
     @mouseout="hovering = false"

--- a/templates/vue/src/components/Lightbox/media/TapestryMedia.vue
+++ b/templates/vue/src/components/Lightbox/media/TapestryMedia.vue
@@ -14,17 +14,21 @@
   >
     <text-media
       v-if="node.mediaType === 'text'"
+      ref="text"
       :node="node"
       :context="context"
+      tabindex="0"
       @complete="complete"
       @load="handleLoad"
     />
     <video-media
       v-if="node.mediaFormat === 'mp4'"
+      ref="mp4"
       :autoplay="autoplay"
       :node="node"
       :dimensions="dimensions"
       :context="context"
+      tabindex="0"
       @load="handleLoad"
       @complete="complete"
       @timeupdate="updateProgress"
@@ -32,10 +36,12 @@
     />
     <youtube-media
       v-if="node.mediaFormat === 'youtube'"
+      ref="youtube"
       :autoplay="autoplay"
       :node="node"
       :dimensions="dimensions"
       :context="context"
+      tabindex="0"
       @load="handleLoad"
       @complete="complete"
       @timeupdate="updateProgress"
@@ -43,18 +49,22 @@
     />
     <external-media
       v-if="node.mediaType === 'url-embed'"
+      ref="url-embed"
       :dimensions="dimensions"
       :node="node"
       :context="context"
+      tabindex="0"
       @load="handleLoad"
       @complete="complete"
     />
     <h5p-media
       v-if="node.mediaFormat === 'h5p'"
+      ref="h5p"
       :autoplay="autoplay"
       :dimensions="dimensions"
       :context="context"
       :node="node"
+      tabindex="0"
       @change:dimensions="$emit('change:dimensions', $event)"
       @load="handleLoad"
       @timeupdate="updateProgress"
@@ -64,22 +74,28 @@
     <gravity-form
       v-if="node.mediaType === 'gravity-form' && !showCompletionScreen"
       :id="node.typeData.mediaURL"
+      ref="gravity-form"
       :node="node"
       :context="context"
+      tabindex="0"
       @submit="handleFormSubmit"
       @load="handleLoad"
     ></gravity-form>
     <wp-post-media
       v-if="node.mediaType === 'wp-post'"
+      ref="wp-post"
       :node="node"
       :context="context"
+      tabindex="0"
       @complete="complete"
       @load="handleLoad"
     ></wp-post-media>
     <activity-media
       v-if="node.mediaType === 'activity'"
+      ref="activity"
       :node="node"
       :context="context"
+      tabindex="0"
       @complete="complete"
       @close="$emit('close')"
       @load="handleLoad"
@@ -174,6 +190,12 @@ export default {
     },
     complete() {
       this.$emit("complete")
+      this.focusMedia()
+    },
+    focusMedia() {
+      const type = this.node.mediaType
+      console.log(this.$refs[type].$el)
+      this.$refs.text.$el.focus()
     },
   },
 }

--- a/templates/vue/src/components/TapestryMain/TapestryNode/NodeButton.vue
+++ b/templates/vue/src/components/TapestryMain/TapestryNode/NodeButton.vue
@@ -2,8 +2,9 @@
   <g
     :transform="`translate(${x}, ${y})`"
     :data-qa="dataQa"
-    :aria-disabled="disabled"
+    tabindex="0"
     @click.stop="$emit('click')"
+    @keyup.enter.space="$emit('click')"
   >
     <circle
       ref="addButton"

--- a/templates/vue/src/components/TapestryMain/TapestryNode/NodeButton.vue
+++ b/templates/vue/src/components/TapestryMain/TapestryNode/NodeButton.vue
@@ -3,6 +3,7 @@
     :transform="`translate(${x}, ${y})`"
     :data-qa="dataQa"
     tabindex="0"
+    :aria-disabled="disabled"
     @click.stop="$emit('click')"
     @keyup.enter.space="$emit('click')"
   >

--- a/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
+++ b/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
@@ -17,6 +17,7 @@
             ? 'pointer'
             : 'not-allowed',
       }"
+      :height="nodeLevel"
       @click="handleClick"
       @mouseover="handleMouseover"
       @mouseleave="handleMouseleave"
@@ -183,6 +184,16 @@ export default {
   computed: {
     ...mapState(["selection", "settings", "visibleNodes"]),
     ...mapGetters(["getNode", "getDirectChildren", "isVisible", "getParent"]),
+    nodeLevel: function() {
+      let counter = -1
+      let temp = this.node
+      while (temp != null) {
+        let nodeID = this.getParent(temp.id)
+        temp = this.getNode(nodeID)
+        counter++
+      }
+      return counter
+    },
     canReview() {
       if (!this.isLoggedIn) {
         return false
@@ -317,12 +328,21 @@ export default {
         .attr("r", newRadius)
     },
   },
+  created() {
+    let counter = -1
+    let temp = this.node
+    while (temp != null) {
+      let nodeID = this.getParent(temp.id)
+      temp = this.getNode(nodeID)
+      counter++
+    }
+  },
   mounted() {
     this.$emit("mounted")
     if (this.root) {
       this.$el.focus()
       this.$el.blur()
-    }
+    } 
     this.$refs.circle.setAttribute("r", this.radius)
     const nodeRef = this.$refs.node
     d3.select(nodeRef).call(
@@ -453,21 +473,21 @@ export default {
     handleClick(evt) {
       const allNodes = document.querySelectorAll(`g[data-id]`)
       allNodes.forEach(node => {
-        node.tabIndex = -1
+        // node.tabIndex = -1
       })
 
       const selectedNode = this.$el
-      selectedNode.tabIndex = 0
+      // selectedNode.tabIndex = 0
 
       const childrenID = this.node.childOrdering
       childrenID.forEach(childID => {
         const childDOM = document.querySelector(`[data-qa="node-${childID}"]`)
-        childDOM.tabIndex = 0
+        // childDOM.tabIndex = 0
       })
       const parentNodeID = this.getParent(this.node.id)
       if (parentNodeID) {
         const parentNode = document.querySelector(`[data-qa="node-${parentNodeID}"`)
-        parentNode.tabIndex = 0
+        // parentNode.tabIndex = 0
       }
 
       if (

--- a/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
+++ b/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
@@ -20,6 +20,8 @@
       @click="handleClick"
       @mouseover="handleMouseover"
       @mouseleave="handleMouseleave"
+      @keyup.enter.space="handleClick"
+      tabindex=0
     >
       <circle ref="circle" :fill="fill"></circle>
       <transition name="fade">

--- a/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
+++ b/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
@@ -319,6 +319,10 @@ export default {
   },
   mounted() {
     this.$emit("mounted")
+    if (this.root) {
+      this.$el.focus()
+      this.$el.blur()
+    }
     this.$refs.circle.setAttribute("r", this.radius)
     const nodeRef = this.$refs.node
     d3.select(nodeRef).call(

--- a/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
+++ b/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
@@ -447,6 +447,25 @@ export default {
       this.$emit("mouseleave")
     },
     handleClick(evt) {
+      const allNodes = document.querySelectorAll(`g[data-id]`)
+      allNodes.forEach(node => {
+        node.tabIndex = -1
+      })
+
+      const selectedNode = this.$el
+      selectedNode.tabIndex = 0
+
+      const childrenID = this.node.childOrdering
+      childrenID.forEach(childID => {
+        const childDOM = document.querySelector(`[data-qa="node-${childID}"]`)
+        childDOM.tabIndex = 0
+      })
+      const parentNodeID = this.getParent(this.node.id)
+      if (parentNodeID) {
+        const parentNode = document.querySelector(`[data-qa="node-${parentNodeID}"`)
+        parentNode.tabIndex = 0
+      }
+
       if (
         this.hasPermission("edit") &&
         (evt.ctrlKey || evt.metaKey || evt.shiftKey)

--- a/templates/vue/src/components/TapestryMain/index.vue
+++ b/templates/vue/src/components/TapestryMain/index.vue
@@ -15,7 +15,7 @@
       </g>
       <g v-if="dragSelectEnabled && dragSelectReady" class="nodes">
         <tapestry-node
-          v-for="(node, id) in nodes"
+          v-for="(node, id) in test(nodes)"
           :key="id"
           :node="node"
           class="node"
@@ -39,7 +39,7 @@
 
 <script>
 import DragSelectModular from "@/utils/dragSelectModular"
-import { mapMutations, mapState } from "vuex"
+import { mapMutations, mapState, mapGetters } from "vuex"
 import TapestryNode from "./TapestryNode"
 import TapestryLink from "./TapestryLink"
 import RootNodeButton from "./RootNodeButton"
@@ -61,6 +61,9 @@ export default {
       dragSelectReady: false,
       activeNode: null,
     }
+  },
+  created() {
+    // console.log(this.nodes)
   },
   mounted() {
     if (this.dragSelectEnabled) {
@@ -118,8 +121,16 @@ export default {
   },
   methods: {
     ...mapMutations(["select", "unselect", "clearSelection"]),
+    ...mapGetters(["getNode", "isMultiContent", "isMultiContentRow"]),
     addRootNode() {
       this.$root.$emit("add-node", null)
+    },
+    test(nodes) {
+      const rootNode = null
+      for (const [id, node] of Object.entries(nodes)) {
+        console.log(node)
+      }
+      return nodes
     },
 
     updateSelectableNodes() {

--- a/templates/vue/src/components/TapestryMain/index.vue
+++ b/templates/vue/src/components/TapestryMain/index.vue
@@ -126,9 +126,23 @@ export default {
       this.$root.$emit("add-node", null)
     },
     test(nodes) {
-      const rootNode = null
-      for (const [id, node] of Object.entries(nodes)) {
-        console.log(node)
+      let originalNodeOrder = Object.entries(nodes)
+      const rootNodeId = this.rootId
+      let newNodeOrder = {}
+      let queue = []
+      // First, find the root node
+      for (const [id, node] of originalNodeOrder) {
+        if (id == rootNodeId) {
+          newNodeOrder[id] = node
+          for (const id of node.childOrdering) {
+            queue.push(id)
+          }
+        }
+      }
+      while (newNodeOrder.length != Object.keys(nodes).length) {
+        const queueLength = queue.length
+        const level = []
+
       }
       return nodes
     },

--- a/templates/vue/src/components/Toolbar/TapestryDepthSlider.vue
+++ b/templates/vue/src/components/Toolbar/TapestryDepthSlider.vue
@@ -233,7 +233,6 @@ export default {
 
 .slider {
   -webkit-appearance: none;
-  outline: none;
   background: #d3d3d3;
   height: 10px;
   opacity: 0.8;
@@ -241,6 +240,11 @@ export default {
   position: relative;
   align-items: center;
   margin: 0 38px;
+
+  &:focus-visible {
+    outline: black solid 4px !important;
+    outline-offset: 5px;
+  }
 
   &:before,
   &:after {
@@ -299,7 +303,6 @@ export default {
 
   &:focus {
     border-color: transparent !important;
-    outline: none !important;
   }
 }
 

--- a/templates/vue/src/components/modals/NodeModal/forms/AppearanceForm.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/AppearanceForm.vue
@@ -3,10 +3,7 @@
     <h6 class="mb-3">Node Appearance</h6>
     <b-card class="px-3 pt-3" bg-variant="light" no-body>
       <b-form-group>
-        <b-form-checkbox 
-        v-model="addThumbnail" 
-        data-qa="node-appearance-thumbnail" 
-        >
+        <b-form-checkbox v-model="addThumbnail" data-qa="node-appearance-thumbnail">
           Add a thumbnail
         </b-form-checkbox>
       </b-form-group>
@@ -25,7 +22,6 @@
         <b-form-checkbox
           v-model="addLockedThumbnail"
           data-qa="node-appearance-lockedThumbnail"
-          
         >
           Show a different thumbnail when locked
         </b-form-checkbox>
@@ -42,7 +38,7 @@
         />
       </b-form-group>
       <b-form-group>
-        <b-form-checkbox v-model="node.hideTitle" data-qa="node-appearance-title" >
+        <b-form-checkbox v-model="node.hideTitle" data-qa="node-appearance-title">
           Hide node title
         </b-form-checkbox>
       </b-form-group>
@@ -50,13 +46,12 @@
         <b-form-checkbox
           v-model="node.hideProgress"
           data-qa="node-appearance-progress"
-          
         >
           Hide progress bar
         </b-form-checkbox>
       </b-form-group>
       <b-form-group>
-        <b-form-checkbox v-model="node.hideMedia" data-qa="node-appearance-media" >
+        <b-form-checkbox v-model="node.hideMedia" data-qa="node-appearance-media">
           Hide media button
         </b-form-checkbox>
       </b-form-group>
@@ -147,10 +142,8 @@ export default {
 </script>
 
 <style lang="scss">
-
 input[type="checkbox"]:focus + label::before {
-    outline: black solid 3px;
-    outline-offset: 5px;
+  outline: black solid 3px;
+  outline-offset: 5px;
 }
-
 </style>

--- a/templates/vue/src/components/modals/NodeModal/forms/AppearanceForm.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/AppearanceForm.vue
@@ -3,7 +3,10 @@
     <h6 class="mb-3">Node Appearance</h6>
     <b-card class="px-3 pt-3" bg-variant="light" no-body>
       <b-form-group>
-        <b-form-checkbox v-model="addThumbnail" data-qa="node-appearance-thumbnail">
+        <b-form-checkbox 
+        v-model="addThumbnail" 
+        data-qa="node-appearance-thumbnail" 
+        >
           Add a thumbnail
         </b-form-checkbox>
       </b-form-group>
@@ -22,6 +25,7 @@
         <b-form-checkbox
           v-model="addLockedThumbnail"
           data-qa="node-appearance-lockedThumbnail"
+          
         >
           Show a different thumbnail when locked
         </b-form-checkbox>
@@ -38,7 +42,7 @@
         />
       </b-form-group>
       <b-form-group>
-        <b-form-checkbox v-model="node.hideTitle" data-qa="node-appearance-title">
+        <b-form-checkbox v-model="node.hideTitle" data-qa="node-appearance-title" >
           Hide node title
         </b-form-checkbox>
       </b-form-group>
@@ -46,12 +50,13 @@
         <b-form-checkbox
           v-model="node.hideProgress"
           data-qa="node-appearance-progress"
+          
         >
           Hide progress bar
         </b-form-checkbox>
       </b-form-group>
       <b-form-group>
-        <b-form-checkbox v-model="node.hideMedia" data-qa="node-appearance-media">
+        <b-form-checkbox v-model="node.hideMedia" data-qa="node-appearance-media" >
           Hide media button
         </b-form-checkbox>
       </b-form-group>
@@ -140,3 +145,12 @@ export default {
   },
 }
 </script>
+
+<style lang="scss">
+
+input[type="checkbox"]:focus + label::before {
+    outline: black solid 3px;
+    outline-offset: 5px;
+}
+
+</style>

--- a/templates/vue/src/components/modals/NodeModal/forms/ContentForm/RichTextForm/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/ContentForm/RichTextForm/index.vue
@@ -307,9 +307,15 @@ h2:after {
 h2:before {
   content: none !important;
 }
+
 .ProseMirror:focus {
   outline: none;
 }
+
+.editor:focus-within:not(:focus-visible) {
+  box-shadow: 0 0 10px 5px LightSkyBlue;
+}
+
 .editor {
   border: 1px solid #ccc;
 }
@@ -364,7 +370,6 @@ h2:before {
     &:focus {
       background-color: rgba($color-black, 0.2);
       background: rgba($color-black, 0.2);
-      outline: unset;
     }
   }
 

--- a/templates/vue/src/components/modals/NodeModal/forms/ContentForm/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/ContentForm/index.vue
@@ -196,4 +196,7 @@ export default {
   padding-top: 3px;
   text-align: right;
 }
+#node-title:focus {
+  box-shadow: 0 0 10px 5px LightSkyBlue;
+}
 </style>

--- a/templates/vue/src/components/modals/NodeModal/forms/CopyrightForm.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/CopyrightForm.vue
@@ -101,4 +101,7 @@ export default {
     }
   }
 }
+input:focus {
+  box-shadow: 0 0 10px 5px LightSkyBlue;
+}
 </style>

--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -1024,13 +1024,16 @@ table {
   font-weight: 600;
 }
 
-:focus-visible:not(input[type='text']):not(p):not(div) {
-  outline: black solid 3px !important;
+.form-control:focus:not(:focus-visible) {
+  outline: none !important;
 }
 
-input[type='checkbox']{
-  outline: black solid 3px !important;
+:focus-visible:not(div):not(p):not(input) {
+  outline: black solid 4px !important;
+  outline-offset: 5px;
 }
+
+
 
 </style>
 

--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -1024,10 +1024,6 @@ table {
   font-weight: 600;
 }
 
-.form-control:focus:not(:focus-visible) {
-  outline: none !important;
-}
-
 :focus-visible:not(div):not(p):not(input) {
   outline: black solid 4px !important;
   outline-offset: 5px;

--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -985,6 +985,7 @@ export default {
 h6 {
   font-weight: 400;
 }
+
 </style>
 
 <style lang="scss">
@@ -1011,10 +1012,6 @@ table {
     position: absolute;
     top: 15px;
     right: 12px;
-
-    &:focus {
-      outline: none;
-    }
   }
 }
 
@@ -1027,9 +1024,14 @@ table {
   font-weight: 600;
 }
 
-.nav-link:focus {
-  outline: none;
+:focus-visible:not(input[type='text']):not(p):not(div) {
+  outline: black solid 3px !important;
 }
+
+input[type='checkbox']{
+  outline: black solid 3px !important;
+}
+
 </style>
 
 <style lang="scss" scoped>

--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -118,7 +118,17 @@
                   :index="index"
                   style="z-index: 9999 !important;"
                 >
-                  <span class="fas fa-bars fa-xs"></span>
+                  <span>
+                    <i class="fas fa-bars fa-xs"></i>
+                  </span>
+                  <span>
+                    <b-button size="sm" @click="moveUp(childId)">
+                      <i class="fa fa-arrow-up" aria-hidden="true"></i>
+                    </b-button>
+                    <b-button size="sm" @click="moveDown(childId)">
+                      <i class="fa fa-arrow-down" aria-hidden="true"></i>
+                    </b-button>
+                  </span>
                   <span>{{ getNode(childId).title }}</span>
                   <span style="color: grey;">id: {{ childId }}</span>
                 </slick-item>
@@ -823,7 +833,10 @@ export default {
       if (this.node.title.length == 0) {
         errMsgs.push("Please enter a title")
       }
-      if (this.node.description.replace(/<[^>]*>?/gm, '').length > this.maxDescriptionLength) {
+      if (
+        this.node.description.replace(/<[^>]*>?/gm, "").length >
+        this.maxDescriptionLength
+      ) {
         errMsgs.push(
           "Please limit your description to under " +
             this.maxDescriptionLength +
@@ -971,6 +984,22 @@ export default {
       )
       this.loadDuration = false
     },
+    moveUp(childID) {
+      console.log(this.node.childOrdering)
+      const ordering = this.node.childOrdering
+      const index = ordering.indexOf(childID)
+      if (index <= 0) {
+        return false
+      } else {
+        const temp = ordering[index]
+        ordering[index] = ordering[index - 1]
+        ordering[index - 1] = temp
+        console.log(this.node.childOrdering)
+      }
+    },
+    moveDown(childID) {
+      console.log(childID)
+    },
   },
 }
 </script>
@@ -985,7 +1014,6 @@ export default {
 h6 {
   font-weight: 400;
 }
-
 </style>
 
 <style lang="scss">
@@ -1028,9 +1056,6 @@ table {
   outline: black solid 4px !important;
   outline-offset: 5px;
 }
-
-
-
 </style>
 
 <style lang="scss" scoped>

--- a/templates/vue/src/components/modals/SettingsModal/index.vue
+++ b/templates/vue/src/components/modals/SettingsModal/index.vue
@@ -544,6 +544,16 @@ export default {
   border: none;
   padding: 0;
   max-width: 350px;
+
+  &:focus-visible {
+    outline: black solid 5px;
+    outline-offset: 5px;
+  }
+}
+
+.background-url {
+  outline: black solid 5px;
+  display: none;
 }
 
 .depth-slider-description {

--- a/templates/vue/src/components/modals/common/FileUpload.vue
+++ b/templates/vue/src/components/modals/common/FileUpload.vue
@@ -94,6 +94,7 @@
             <b-col :class="{ 'pl-0': !showImagePreview }">
               <b-form-input
                 name="text-input"
+                class="text-input"
                 :placeholder="placeholder"
                 :value="value"
                 :data-qa="inputTestId"
@@ -310,6 +311,14 @@ export default {
 .image-file {
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.image-file:focus {
+  box-shadow: 0 0 10px 5px LightSkyBlue;
+}
+
+.text-input:focus {
+  box-shadow: 0 0 10px 5px LightSkyBlue;
 }
 
 .divider {

--- a/templates/vue/src/components/modals/common/PermissionsTable.vue
+++ b/templates/vue/src/components/modals/common/PermissionsTable.vue
@@ -244,4 +244,7 @@ table {
     border-top: none;
   }
 }
+input:focus {
+  box-shadow: 0 0 10px 5px LightSkyBlue;
+}
 </style>


### PR DESCRIPTION
## Changes
This PR removes many instances of `outline: none` CSS styles such that outlines for keyboard navigation users shows up for better accessibility. Typically [outlines](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) are [removed for aesthetic purposes](https://css-tricks.com/almanac/selectors/f/focus-visible/), but this is [terrible for accessibility](https://www.a11yproject.com/posts/2013-01-25-never-remove-css-outlines/). 

In addition, this PR also adds high visibility CSS `outlines` for keyboard navigation users to make the basic keyboard navigation support explicit by drawing a [VoiceOver-like](https://en.wikipedia.org/wiki/VoiceOver) cursor outline. This is done by using the `:focus-visible` pseudo-class. See example screenshot below.

## Screenshot
![image](https://user-images.githubusercontent.com/11191061/120533256-652e2b00-c395-11eb-96b8-d08980e00dfa.png)
![image](https://user-images.githubusercontent.com/11191061/120533386-868f1700-c395-11eb-9008-b7402f101499.png)

## Issue Linkage
Closes #1037 
## Depends on: (PR # or N/A)
N/A
## Automated Testing (:information_source: : Please read notes)
Due to the limitations of [Cypress](https://docs.cypress.io/api/commands/type), which does not allow us to realistically test browser keyboard focus and navigation functionality, it's best for testers to test this PR using their own browser environment. Ensure your browser do not have anything that overrides the `:focus-visible` CSS pseudo-class, and try to navigate through all the tapestry on-screen elements by using tab. 

You can tab forward by pressing `TAB`, go back to the previous element by pressing `SHIFT+TAB`. To activate and "click" an element, press `ENTER`. Clicking an element should yield identical behaviour as a mouse click. For modifying sliders, use your `LEFT` and `RIGHT` arrow keys.

## Appendix: Using Tapestry with a Screen-reader (VoiceOver, MacOS version 11.4)

Currently tapestry support for screen readers are limited, with the main tapestry screen of nodes being recognised as an image and cannot be interacted with.

https://user-images.githubusercontent.com/11191061/121578928-11988e80-c9e0-11eb-9dcf-78fcc7907b81.mov


