### PR TITLE
1059 - TYDE2 - Fix aspect ratio for h5p videos

### DIFF
--- a/classes/class.tapestry-h5p.php
+++ b/classes/class.tapestry-h5p.php
@@ -19,7 +19,7 @@ class TapestryH5P implements ITapestryH5P
     public function get()
     {
         global $wpdb;
-        $content = $wpdb->get_results('select content.id as id, content.title as title, content.filtered as details, name as library from '.$wpdb->prefix.'h5p_contents content join '.$wpdb->prefix.'h5p_libraries lib on content.library_id = lib.id');
+        $content = $wpdb->get_results('select content.id as id, content.title as title, content.filtered as details, content.parameters, name as library from '.$wpdb->prefix.'h5p_contents content join '.$wpdb->prefix.'h5p_libraries lib on content.library_id = lib.id');
 
         return $content;
     }

--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -654,6 +654,10 @@ class Tapestry implements ITapestry
                     $H5PIndex = array_search($H5PId, array_column($allH5Ps, 'id'));
                     if ($H5PIndex || 0 == $H5PIndex) {
                         $nodes[$i]->typeData->h5pMeta = $allH5Ps[$H5PIndex];
+                        // Could not get h5pMeta to populate with fresh data,
+                        // so had to create a new property here.
+                        // TODO: Figure out a way not to have to do this
+                        $nodes[$i]->typeData->h5pMeta2 = $allH5Ps[$H5PIndex];
                     }
                 }
             }

--- a/templates/vue/src/components/Lightbox/media/MultiContentMedia/PageRows.vue
+++ b/templates/vue/src/components/Lightbox/media/MultiContentMedia/PageRows.vue
@@ -41,7 +41,7 @@
             <div v-if="row.node.mediaType !== 'multi-content'">
               <tapestry-media
                 :node-id="row.node.id"
-                :dimensions="innerDimensions"
+                :dimensions="getRowDimensions(row.node)"
                 context="page"
                 style="margin-bottom: 24px;"
                 @complete="updateProgress(row.node.id)"
@@ -52,7 +52,7 @@
               </p>
               <accordion-rows
                 v-if="row.children.length > 0"
-                :dimensions="innerDimensions"
+                :dimensions="getRowDimensions(row.node)"
                 :node="row.node"
                 :rowId="subRowId"
                 context="page"
@@ -172,12 +172,6 @@ export default {
         return null
       }
     },
-    innerDimensions() {
-      return {
-        ...this.dimensions,
-        width: this.dimensions.width - 32, // excludes padding
-      }
-    },
   },
   mounted() {
     this.$root.$emit("observe-rows", this.$refs.rowRefs)
@@ -193,6 +187,13 @@ export default {
         (this.lockRows && this.disabledFrom >= 0 && index > this.disabledFrom) ||
         !node.unlocked
       )
+    },
+    getRowDimensions(node) {
+      const widthMultiplier = node ? 1 : 1 // this should be updated when half-width feature is here
+      return {
+        ...this.dimensions,
+        width: (this.dimensions.width - 32) * widthMultiplier, // excludes padding
+      }
     },
     updateProgress(rowId) {
       this.$emit("updateProgress", rowId)

--- a/templates/vue/src/components/Lightbox/media/MultiContentMedia/PageRows.vue
+++ b/templates/vue/src/components/Lightbox/media/MultiContentMedia/PageRows.vue
@@ -41,7 +41,7 @@
             <div v-if="row.node.mediaType !== 'multi-content'">
               <tapestry-media
                 :node-id="row.node.id"
-                :dimensions="dimensions"
+                :dimensions="innerDimensions"
                 context="page"
                 style="margin-bottom: 24px;"
                 @complete="updateProgress(row.node.id)"
@@ -52,7 +52,7 @@
               </p>
               <accordion-rows
                 v-if="row.children.length > 0"
-                :dimensions="dimensions"
+                :dimensions="innerDimensions"
                 :node="row.node"
                 :rowId="subRowId"
                 context="page"
@@ -170,6 +170,12 @@ export default {
         }
       } else {
         return null
+      }
+    },
+    innerDimensions() {
+      return {
+        ...this.dimensions,
+        width: this.dimensions.width - 32, // excludes padding
       }
     },
   },

--- a/templates/vue/src/components/Lightbox/media/VideoMedia/H5PVideoMedia.vue
+++ b/templates/vue/src/components/Lightbox/media/VideoMedia/H5PVideoMedia.vue
@@ -314,7 +314,7 @@ export default {
       const aspectRatio = aspectRatioStr.split(":")
       this.frameHeight = (this.dimensions.width / aspectRatio[0]) * aspectRatio[1]
       // Add height for the video controls
-      this.frameHeight += 38
+      this.frameHeight += Math.min(38, this.frameHeight * 0.08)
       this.frameWidth = 0
 
       this.$emit("change:dimensions", { height: this.frameHeight })

--- a/templates/vue/src/components/Lightbox/media/VideoMedia/index.vue
+++ b/templates/vue/src/components/Lightbox/media/VideoMedia/index.vue
@@ -3,7 +3,7 @@
     <h1 v-if="showTitle" class="video-title">{{ node.title }}</h1>
     <div
       :style="{
-        height: `${dimensions.height}px`,
+        height: heightCss,
         width: '100%',
       }"
     >
@@ -172,6 +172,13 @@ export default {
           return "h5p-video-media"
         default:
           throw new Error(`Unknown video type: ${this.node.mediaFormat}`)
+      }
+    },
+    heightCss() {
+      if (this.videoComponent == "h5p-video-media" && this.context == "page") {
+        return "auto"
+      } else {
+        return this.dimensions.height + "px"
       }
     },
     popups() {


### PR DESCRIPTION
## Changes
* H5P stores the aspect ratio for some interactive videos. We want to use this to figure out the height of the video and its container as the current method has not proven very reliable
* If no aspect ratio is available, use a default aspect ratio of 16:9 (we should ideally let users define this default aspect ratio in the tapestry settings and also be able to override it per node)

Note: this is only relevant to h5p videos from youtube
## Screenshot
N/A
## Issue Linkage
Closes #1059
## PR Dependency
N/A
## Automated Testing
N/A