### PR TITLE
1176 - Bug fix: Creating cycles with Multicontent causes Tapestry to freeze

### DIFF
--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -452,7 +452,7 @@ export default {
       let parents = []
       let parentId
       let parent = this.parent
-      while (parent != null) {
+      while (parent != null && parent.mediaType == "multi-content") {
         parents.unshift(parent)
         parentId = this.getParent(parent.id)
         parent = parentId ? this.getNode(parentId) : null


### PR DESCRIPTION
## Changes
* Add check for parent mediaType
## Issue Linkage
Closes #1176 
## PR Dependency
Depends on: N/A
## Automated Testing
N/A
