### PR TITLE
1192 - Replace deprecated Cypress commands

### DIFF
--- a/templates/vue/cypress/integration/import-export.spec.js
+++ b/templates/vue/cypress/integration/import-export.spec.js
@@ -2,8 +2,7 @@ describe("Import Export", () => {
   it("should be able to export a Tapestry", () => {
     cy.fixture("one-node.json").as("oneNode")
     cy.setup("@oneNode")
-    cy.server()
-    cy.route("GET", "**/tapestries/**/export").as("export")
+    cy.intercept("GET", "**/tapestries/**/export").as("export")
 
     cy.get(".settings-button").click()
     cy.contains(/advanced/i).click()
@@ -21,9 +20,8 @@ describe("Import Export", () => {
   it("should be able to import a Tapestry using file input", () => {
     const tapestry = "full-featured-exported-tapestry.json"
     cy.setup()
-    cy.server()
-    cy.route("PUT", "**/tapestries/**").as("import")
-    cy.route("GET", "**/tapestries/**").as("load")
+    cy.intercept("PUT", "**/tapestries/**").as("import")
+    cy.intercept("GET", "**/tapestries/**").as("load")
 
     cy.getByTestId("import-file-input").attachFile(tapestry)
     cy.wait("@import")
@@ -44,9 +42,8 @@ describe("Import Export", () => {
     const tapestry = "one-node.json"
     cy.setup()
 
-    cy.server()
-    cy.route("PUT", "**/tapestries/**").as("import")
-    cy.route("GET", "**/tapestries/**").as("load")
+    cy.intercept("PUT", "**/tapestries/**").as("import")
+    cy.intercept("GET", "**/tapestries/**").as("load")
 
     cy.getByTestId("import-file-input").attachFile(tapestry)
     cy.wait("@import")

--- a/templates/vue/cypress/integration/lightbox/activity.spec.js
+++ b/templates/vue/cypress/integration/lightbox/activity.spec.js
@@ -22,6 +22,8 @@ describe("Activity", () => {
         .first()
         .getByTestId("import-file-input")
         .attachFile("reddit.png")
+      cy.wait("@upload")
+      cy.get(".custom-file-label").contains("reddit.png")
       cy.get(".item-text")
         .first()
         .type("item 1")
@@ -36,7 +38,7 @@ describe("Activity", () => {
         .type(toBucketLabel2)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.intercept("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         const dataTransfer = new DataTransfer()
         cy.get(".user-item")
@@ -46,6 +48,7 @@ describe("Activity", () => {
           .last()
           .trigger("drop", { dataTransfer })
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.contains("You can press the button below to continue.").should(
           "be.visible"
         )
@@ -109,7 +112,7 @@ describe("Activity", () => {
         .type(toBucketLabel2)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.intercept("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         //cy.get("input").type(answer)
         const dataTransfer = new DataTransfer()
@@ -152,6 +155,7 @@ describe("Activity", () => {
           .first()
           .trigger("drop", { dataTransfer })
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.contains("You can press the button below to continue.").should(
           "be.visible"
         )
@@ -215,7 +219,7 @@ describe("Activity", () => {
         .type(toBucketLabel2)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.intercept("POST", "**/quiz*").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         const dataTransfer = new DataTransfer()
         cy.get(".user-item")
@@ -231,6 +235,7 @@ describe("Activity", () => {
           .last()
           .trigger("drop", { dataTransfer })
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.contains("You can press the button below to continue.").should(
           "be.visible"
         )
@@ -267,7 +272,7 @@ describe("Activity", () => {
         .type("3")
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.intercept("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         cy.getByTestId(`multiple-choice-question-0`)
           .getByTestId(`multiple-choice-question-item-0-checked`)
@@ -276,6 +281,7 @@ describe("Activity", () => {
           .getByTestId(`multiple-choice-question-item-1-checked`)
           .click({ force: true })
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.contains("You can press the button below to continue.").should(
           "be.visible"
         )
@@ -309,12 +315,13 @@ describe("Activity", () => {
         .type("10")
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.intercept("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         cy.getByTestId(`multiple-choice-question-2`)
           .getByTestId(`multiple-choice-question-item-2-checked`)
           .click({ force: true })
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.contains("You can press the button below to continue.").should(
           "be.visible"
         )
@@ -348,7 +355,7 @@ describe("Activity", () => {
       cy.getByTestId("question-answer-text-single-placeholder-1").type(placeholder2)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.intercept("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${placeholder}"]`).should("be.visible")
         cy.getByTestId("question-prev-button").should("be.disabled")
@@ -362,8 +369,10 @@ describe("Activity", () => {
         cy.get(`[placeholder="${placeholder}"]`).should("be.visible")
         cy.get("input").type(answer)
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.get("input").type(answer2)
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.contains("You can press the button below to continue.").should(
           "be.visible"
         )
@@ -388,11 +397,12 @@ describe("Activity", () => {
       cy.getByTestId("question-answer-text-single-placeholder-0").type(placeholder)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.intercept("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${placeholder}"]`).should("be.visible")
         cy.get("input").type(answer)
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.contains("You can press the button below to continue.").should(
           "be.visible"
         )
@@ -410,10 +420,11 @@ describe("Activity", () => {
       cy.submitModal()
       cy.openLightbox(node.id)
       cy.contains(/Change answers/i).click()
-      cy.intercept("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         cy.get("textarea").type(answer2)
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.contains("You can press the button below to continue.").should(
           "be.visible"
         )
@@ -438,11 +449,12 @@ describe("Activity", () => {
       cy.getByTestId("question-answer-text-single-placeholder-0").type(placeholder)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.intercept("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${placeholder}"]`).should("be.visible")
         cy.get("input").type(answer)
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.contains("You can press the button below to continue.").should(
           "be.visible"
         )
@@ -497,7 +509,7 @@ describe("Activity", () => {
       cy.getByTestId("enable-list-checkbox").click({ force: true })
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.intercept("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${listPlaceholder}"]`).should("be.visible")
         cy.getByTestId("list-input-0").type("British Columbia")
@@ -508,6 +520,7 @@ describe("Activity", () => {
         cy.getByTestId("list-add-2").click()
         cy.getByTestId("list-input-3").type("Manitoba")
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.contains("You can press the button below to continue.").should(
           "be.visible"
         )
@@ -548,7 +561,7 @@ describe("Activity", () => {
       cy.getByTestId("max-list-fields-input").type(maxFieldsValue)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.intercept("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${listPlaceholder}"]`).should("be.visible")
         cy.get(`.activity-media`).scrollTo("bottom", {
@@ -564,6 +577,7 @@ describe("Activity", () => {
           cy.getByTestId(`list-input-${index}`).type(`Thing ${index}`)
           if (index === 9) {
             cy.contains(/submit/i).click()
+            cy.wait("@submit")
             cy.contains("You can press the button below to continue.").should(
               "be.visible"
             )
@@ -604,7 +618,6 @@ describe("Activity", () => {
       cy.getByTestId("question-answer-text-single-placeholder-0").type(placeholder)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         cy.contains(/skip/i).click()
         cy.contains("You can press the button below to continue.").should(

--- a/templates/vue/cypress/integration/lightbox/activity.spec.js
+++ b/templates/vue/cypress/integration/lightbox/activity.spec.js
@@ -17,8 +17,7 @@ describe("Activity", () => {
         .click({ force: true })
         .type(fromBucketLabel1)
       cy.getByTestId("dragdrop-use-images").click({ force: true })
-      cy.server()
-      cy.route("POST", "**/async-upload.php").as("upload")
+      cy.intercept("POST", "**/async-upload.php").as("upload")
       cy.get(".custom-file-input")
         .first()
         .getByTestId("import-file-input")
@@ -37,7 +36,7 @@ describe("Activity", () => {
         .type(toBucketLabel2)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         const dataTransfer = new DataTransfer()
         cy.get(".user-item")
@@ -110,7 +109,7 @@ describe("Activity", () => {
         .type(toBucketLabel2)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         //cy.get("input").type(answer)
         const dataTransfer = new DataTransfer()
@@ -216,7 +215,7 @@ describe("Activity", () => {
         .type(toBucketLabel2)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "**/quiz*").as("submit")
+      cy.intercept("POST", "**/quiz*").as("submit")
       cy.lightbox().within(() => {
         const dataTransfer = new DataTransfer()
         cy.get(".user-item")
@@ -268,7 +267,7 @@ describe("Activity", () => {
         .type("3")
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         cy.getByTestId(`multiple-choice-question-0`)
           .getByTestId(`multiple-choice-question-item-0-checked`)
@@ -310,7 +309,7 @@ describe("Activity", () => {
         .type("10")
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         cy.getByTestId(`multiple-choice-question-2`)
           .getByTestId(`multiple-choice-question-item-2-checked`)
@@ -349,7 +348,7 @@ describe("Activity", () => {
       cy.getByTestId("question-answer-text-single-placeholder-1").type(placeholder2)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${placeholder}"]`).should("be.visible")
         cy.getByTestId("question-prev-button").should("be.disabled")
@@ -389,7 +388,7 @@ describe("Activity", () => {
       cy.getByTestId("question-answer-text-single-placeholder-0").type(placeholder)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${placeholder}"]`).should("be.visible")
         cy.get("input").type(answer)
@@ -411,7 +410,7 @@ describe("Activity", () => {
       cy.submitModal()
       cy.openLightbox(node.id)
       cy.contains(/Change answers/i).click()
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         cy.get("textarea").type(answer2)
         cy.contains(/submit/i).click()
@@ -439,7 +438,7 @@ describe("Activity", () => {
       cy.getByTestId("question-answer-text-single-placeholder-0").type(placeholder)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${placeholder}"]`).should("be.visible")
         cy.get("input").type(answer)
@@ -498,7 +497,7 @@ describe("Activity", () => {
       cy.getByTestId("enable-list-checkbox").click({ force: true })
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${listPlaceholder}"]`).should("be.visible")
         cy.getByTestId("list-input-0").type("British Columbia")
@@ -549,7 +548,7 @@ describe("Activity", () => {
       cy.getByTestId("max-list-fields-input").type(maxFieldsValue)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${listPlaceholder}"]`).should("be.visible")
         cy.get(`.activity-media`).scrollTo("bottom", {
@@ -605,7 +604,7 @@ describe("Activity", () => {
       cy.getByTestId("question-answer-text-single-placeholder-0").type(placeholder)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         cy.contains(/skip/i).click()
         cy.contains("You can press the button below to continue.").should(

--- a/templates/vue/cypress/integration/lightbox/answer.spec.js
+++ b/templates/vue/cypress/integration/lightbox/answer.spec.js
@@ -3,9 +3,8 @@ describe("Answers", () => {
     cy.fixture("one-node.json").as("oneNode")
     cy.setup("@oneNode")
 
-    cy.server()
-    cy.route("POST", `**/nodes`).as("addNode")
-    cy.route("PUT", `**/nodes/**`).as("editNode")
+    cy.intercept("POST", `**/nodes`).as("addNode")
+    cy.intercept("PUT", `**/nodes/**`).as("editNode")
 
     cy.getSelectedNode().then(node => {
       cy.openModal("edit", node.id)
@@ -20,7 +19,7 @@ describe("Answers", () => {
       cy.getByTestId("question-answer-text-single-placeholder-0").type(placeholder)
       cy.submitModal()
       cy.openLightbox(node.id)
-      cy.route("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "/users/activity/**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${placeholder}"]`).should("be.visible")
         cy.get("input").type(answer)

--- a/templates/vue/cypress/integration/lightbox/answer.spec.js
+++ b/templates/vue/cypress/integration/lightbox/answer.spec.js
@@ -17,13 +17,15 @@ describe("Answers", () => {
       cy.getByTestId("question-answer-text-0").click({ force: true })
       cy.getByTestId("question-answer-text-single-0").click({ force: true })
       cy.getByTestId("question-answer-text-single-placeholder-0").type(placeholder)
-      cy.submitModal()
+      cy.getByTestId("submit-node-modal").click()
+      cy.wait("@editNode")
       cy.openLightbox(node.id)
-      cy.intercept("POST", "/users/activity/**").as("submit")
+      cy.intercept("POST", "**/users/activity?**").as("submit")
       cy.lightbox().within(() => {
         cy.get(`[placeholder="${placeholder}"]`).should("be.visible")
         cy.get("input").type(answer)
         cy.contains(/submit/i).click()
+        cy.wait("@submit")
         cy.contains("You can press the button below to continue.").should(
           "be.visible"
         )

--- a/templates/vue/cypress/integration/lightbox/multicontent.spec.js
+++ b/templates/vue/cypress/integration/lightbox/multicontent.spec.js
@@ -23,10 +23,9 @@ describe("Multi-content", () => {
           .should("exist")
       }
 
-      cy.server()
-      cy.route("POST", `**/nodes`).as("addNode")
-      cy.route("PUT", `**/nodes/**`).as("editNode")
-      cy.route("DELETE", `**/nodes/**`).as("deleteNode")
+      cy.intercept("POST", `**/nodes`).as("addNode")
+      cy.intercept("PUT", `**/nodes/**`).as("editNode")
+      cy.intercept("DELETE", `**/nodes/**`).as("deleteNode")
 
       // Add multi-content node
       cy.getByTestId(`root-node-button`).click()

--- a/templates/vue/cypress/integration/lightbox/wordpress.spec.js
+++ b/templates/vue/cypress/integration/lightbox/wordpress.spec.js
@@ -9,8 +9,7 @@ describe("Wordpress", () => {
       cy.openModal("edit", node.id)
       cy.changeMediaType("wp-post")
 
-      cy.server()
-      cy.route("GET", /posts/i).as("getPosts")
+      cy.intercept("GET", /posts/i).as("getPosts")
 
       cy.getByTestId("wp-combobox").click()
       cy.wait("@getPosts")

--- a/templates/vue/cypress/integration/node-appearance.spec.js
+++ b/templates/vue/cypress/integration/node-appearance.spec.js
@@ -23,12 +23,13 @@ describe("Node Appearance", () => {
       cy.contains(/hide progress bar/i).click()
       cy.contains(/background image/i).click()
 
-      cy.server()
-      cy.route("POST", "**/async-upload.php").as("upload")
+      cy.intercept("POST", "**/async-upload.php").as("upload")
 
       cy.getByTestId("import-file-input").attachFile("reddit.png")
       cy.wait("@upload")
-        .its("response.body.data.url")
+        .then(({ response }) => {
+          return JSON.parse(response.body).data.url
+        })
         .then(() => {
           cy.get("No image").should("not.exist")
           cy.get(".alert-success").should("exist")

--- a/templates/vue/cypress/integration/node-authoring.spec.js
+++ b/templates/vue/cypress/integration/node-authoring.spec.js
@@ -129,8 +129,7 @@ describe("Node Authoring", () => {
         cy.contains(/delete node/i).should("be.visible")
 
         // Expect delete to delete node
-        cy.server()
-        cy.route("DELETE", `**/nodes/**`).as("deleteNode")
+        cy.intercept("DELETE", `**/nodes/**`).as("deleteNode")
 
         cy.contains(/delete/i).click()
         cy.contains(modalTitle).should("be.visible")

--- a/templates/vue/cypress/integration/node-locked.spec.js
+++ b/templates/vue/cypress/integration/node-locked.spec.js
@@ -38,8 +38,7 @@ describe("Locked Nodes", () => {
         cy.getNodeById(child.id).click()
         cy.contains(/this content will be unlocked/i).should("be.visible")
 
-        cy.server()
-        cy.route("POST", "**/progress").as("complete")
+        cy.intercept("POST", "**/progress").as("complete")
 
         cy.openLightbox(root.id).should("exist")
         cy.closeLightbox()

--- a/templates/vue/cypress/integration/settings.spec.js
+++ b/templates/vue/cypress/integration/settings.spec.js
@@ -29,12 +29,13 @@ describe("Settings", () => {
   })
 
   it(`should be able to set a background image`, () => {
-    cy.server()
-    cy.route("POST", "**/async-upload.php").as("upload")
+    cy.intercept("POST", "**/async-upload.php").as("upload")
 
     cy.get("[name=async-upload]").attachFile("reddit.png")
     cy.wait("@upload")
-      .its("response.body.data.url")
+      .then(({ response }) => {
+        return JSON.parse(response.body).data.url
+      })
       .then(url => {
         cy.getByTestId("node-upload-input").should("have.value", url)
         cy.submitSettingsModal()
@@ -45,8 +46,7 @@ describe("Settings", () => {
   it(`should be able to duplicate a tapestry`, () => {
     cy.contains(/advanced/i).click()
 
-    cy.server()
-    cy.route("POST", "**/tapestries").as("duplicate")
+    cy.intercept("POST", "**/tapestries").as("duplicate")
 
     cy.contains(/duplicate tapestry/i).click()
     cy.getByTestId("spinner").should("be.visible")

--- a/templates/vue/cypress/support/commands.js
+++ b/templates/vue/cypress/support/commands.js
@@ -60,8 +60,7 @@ Cypress.Commands.add("getSelectedNode", () =>
 )
 
 Cypress.Commands.add("addNode", { prevSubject: false }, (parent, node) => {
-  cy.server()
-  cy.route("POST", `**/nodes`).as("addNode")
+  cy.intercept("POST", `**/nodes`).as("addNode")
   cy.store().then(store => {
     store.dispatch("addNode", deepMerge(store.getters.createDefaultNode(), node))
     cy.wait("@addNode")
@@ -75,8 +74,7 @@ Cypress.Commands.add("addNode", { prevSubject: false }, (parent, node) => {
 })
 
 Cypress.Commands.add("editNode", { prevSubject: false }, (id, newNode) => {
-  cy.server()
-  cy.route("PUT", `**/nodes/**`).as("editNode")
+  cy.intercept("PUT", `**/nodes/**`).as("editNode")
 
   cy.store().then(store => store.dispatch("updateNode", { id, newNode }))
 
@@ -87,8 +85,7 @@ Cypress.Commands.add(
   "updateNodeProgress",
   { prevSubject: false },
   (id, progress) => {
-    cy.server()
-    cy.route("POST", `**/users/progress`).as("saveProgress")
+    cy.intercept("POST", `**/users/progress`).as("saveProgress")
 
     cy.store().then(store => store.dispatch("updateNodeProgress", { id, progress }))
 
@@ -102,8 +99,7 @@ Cypress.Commands.add(
 )
 
 Cypress.Commands.add("deleteNode", () => {
-  cy.server()
-  cy.route("DELETE", `**/nodes/**`).as("deleteNode")
+  cy.intercept("DELETE", `**/nodes/**`).as("deleteNode")
 
   cy.contains(/delete/i).click()
   cy.wait("@deleteNode")
@@ -136,8 +132,7 @@ Cypress.Commands.add("link", (source, target) =>
 )
 
 Cypress.Commands.add("addLink", (source, target) => {
-  cy.server()
-  cy.route("POST", "**/links").as("postLink")
+  cy.intercept("POST", "**/links").as("postLink")
   cy.store()
     .its("dispatch")
     .then(dispatch => dispatch("addLink", { source, target }))
@@ -160,16 +155,14 @@ Cypress.Commands.add("openModal", (type, id) => {
 })
 
 Cypress.Commands.add("submitModal", () => {
-  cy.server()
-  cy.route("PUT", `**/nodes/**/permissions`).as("editPermissions")
+  cy.intercept("PUT", `**/nodes/**/permissions`).as("editPermissions")
 
   cy.getByTestId("submit-node-modal").click()
   cy.getByTestId("node-modal", { timeout: 10000 }).should("not.exist")
 })
 
 Cypress.Commands.add("submitSettingsModal", () => {
-  cy.server()
-  cy.route("PUT", `**/settings`).as("save")
+  cy.intercept("PUT", `**/settings`).as("save")
 
   cy.getByTestId("settings-modal").within(() => {
     cy.getByTestId("submit-button").click()

--- a/templates/vue/cypress/support/commands.js
+++ b/templates/vue/cypress/support/commands.js
@@ -85,8 +85,6 @@ Cypress.Commands.add(
   "updateNodeProgress",
   { prevSubject: false },
   (id, progress) => {
-    cy.intercept("POST", `**/users/progress`).as("saveProgress")
-
     cy.store().then(store => store.dispatch("updateNodeProgress", { id, progress }))
 
     cy.store()
@@ -155,8 +153,6 @@ Cypress.Commands.add("openModal", (type, id) => {
 })
 
 Cypress.Commands.add("submitModal", () => {
-  cy.intercept("PUT", `**/nodes/**/permissions`).as("editPermissions")
-
   cy.getByTestId("submit-node-modal").click()
   cy.getByTestId("node-modal", { timeout: 10000 }).should("not.exist")
 })


### PR DESCRIPTION
## Changes
* Replaces deprecated `cy.server` and `cy.route` commands in the Cypress tests with `cy.intercept` (see [here](https://docs.cypress.io/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept))
* Addresses some interceptions whose results are never used in the tests, by either deleting or `cy.wait`-ing on them

## Issue Linkage
Closes #1192
## PR Dependency
Depends on: N/A
## Automated Testing
N/A