### PR TITLE
1200 - Bug fix: Empty H5P dropdown

### DIFF
--- a/templates/vue/src/services/H5PApi.js
+++ b/templates/vue/src/services/H5PApi.js
@@ -16,11 +16,18 @@ export default {
 function parse(response) {
   if (response && response.length) {
     return response.map(({ id, title, library, details }) => {
+      let detailsObject = {}
+      try {
+        detailsObject = JSON.parse(details)
+      } catch (error) {
+        // ignore
+      }
+
       return {
         id,
         title: Helpers.decodeHTMLChars(title),
         library,
-        details: JSON.parse(details),
+        details: detailsObject,
       }
     })
   }


### PR DESCRIPTION
## Changes
* If the `details` field of the H5P is empty or otherwise invalid JSON, set `details` to an empty object by default rather than throwing an error.

**Testing**:
The issue seems to occur when at least one H5P has an empty `filtered` attribute in the `wp_h5p_contents` database. See the difference below:

![image](https://user-images.githubusercontent.com/44929104/176562074-9829c000-e435-48e6-9cd8-daf2632ce866.png)

To reproduce the bug, you could try manually deleting this attribute in the database, then see if this fixes it.

## Issue Linkage
Closes #1200 
## PR Dependency
Depends on: N/A
## Automated Testing
N/A