### PR TITLE
1205 - General UX updates to authoring

### DIFF
--- a/templates/vue/src/components/modals/NodeModal/DeleteNodeButton.vue
+++ b/templates/vue/src/components/modals/NodeModal/DeleteNodeButton.vue
@@ -6,6 +6,7 @@
       variant="danger"
       @click="handleRemoveNode"
     >
+      <i class="fas fa-trash-alt mr-1"></i>
       Delete Node
     </b-button>
   </div>

--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -187,7 +187,7 @@
               :disabled="loading || fileUploading || fieldsInvalid"
               @click="handlePublish"
             >
-              <span>Publish</span>
+              <span>Save and Publish</span>
             </b-button>
             <b-button
               v-else-if="settings.submitNodesEnabled"

--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -343,9 +343,7 @@ export default {
     },
     title() {
       if (this.type === "add") {
-        return this.parent
-          ? `Add new sub-topic to ${this.parent.title}`
-          : "Add root node"
+        return this.parent ? `Add node to ${this.parent.title}` : "Add root node"
       } else if (this.type === "edit") {
         return `Edit node: ${this.node.title}`
       }

--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -1173,14 +1173,6 @@ export default {
             this.update("thumbnailFileId", "")
             this.update("imageURL", data.image)
           }
-          if (
-            confirm(
-              "Would you like to use the link preview image as the locked thumbnail image?"
-            )
-          ) {
-            this.update("lockedThumbnailFileId", "")
-            this.update("lockedImageURL", data.image)
-          }
         }
       }
     },

--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -27,6 +27,8 @@
           <i class="fas fa-chevron-right fa-xs mx-2" />
         </b-link>
       </span>
+      <i v-if="type === 'add'" class="fas fa-plus fa-xs mr-1" />
+      <i v-else-if="type === 'edit'" class="fas fa-pen fa-xs mr-1" />
       <span data-qa="node-modal-header">
         {{ title }}
       </span>


### PR DESCRIPTION
## Changes
* Make it more clear if they are on “Add Node” or “Edit Node”
* When the node URL is updated or added, don’t ask if they want to set locked thumbnail and do not automatically set locked thumbnail. Keep doing this for the regular thumbnail, though.
* Change “Publish” to “Save and publish”
* Add trash icon to delete button
## Screenshot

Changes are highlighted in green:
<img width="794" alt="image" src="https://user-images.githubusercontent.com/12668055/177688731-82fcf0ec-ff02-428f-85a3-bd60fcf11715.png">

## Issue Linkage
Closes #1205 
## PR Dependency
Depends on: N/A
## Automated Testing
* N/A
