### PR TITLE
1209 - Bug fix: Unable to scroll on mobile

### DIFF
--- a/templates/vue/src/components/TapestryMain/index.vue
+++ b/templates/vue/src/components/TapestryMain/index.vue
@@ -13,7 +13,7 @@
           :target="nodes[link.target]"
         ></tapestry-link>
       </g>
-      <g v-if="dragSelectEnabled && dragSelectReady" class="nodes">
+      <g v-if="!dragSelectEnabled || dragSelectReady" class="nodes">
         <tapestry-node
           v-for="(node, id) in nodes"
           :key="id"
@@ -82,7 +82,7 @@ export default {
       return Number(this.$route.params.nodeId)
     },
     dragSelectEnabled() {
-      return !this.settings.renderMap
+      return !this.settings.renderMap && !Helpers.isTouchEnabledDevice()
     },
     editableNodes() {
       return this.nodes.length

--- a/templates/vue/src/components/TapestryMain/index.vue
+++ b/templates/vue/src/components/TapestryMain/index.vue
@@ -82,7 +82,7 @@ export default {
       return Number(this.$route.params.nodeId)
     },
     dragSelectEnabled() {
-      return !this.settings.renderMap && !Helpers.isTouchEnabledDevice()
+      return !Helpers.isTouchEnabledDevice()
     },
     editableNodes() {
       return this.nodes.length

--- a/templates/vue/src/utils/Helpers.js
+++ b/templates/vue/src/utils/Helpers.js
@@ -36,6 +36,15 @@ export default class Helpers {
   }
 
   /**
+   * Check if user is on a touch enabled device
+   *
+   * @returns {Boolean}
+   */
+  static isTouchEnabledDevice() {
+    return "ontouchstart" in window || navigator.maxTouchPoints > 0
+  }
+
+  /**
    * Finds the node index with node ID
    *
    * @param  {Number} id          nodeMetaId


### PR DESCRIPTION
## Changes
* Disable dragSelect on touch enabled devices so users can scroll the page normally.

## Screenshot
* N/A
## Issue Linkage
Closes #1209 
## PR Dependency
Depends on: N/A
## Automated Testing
* N/A
