### PR TITLE
1228 - Bug fix: Lightbox height becomes 0 for some H5P nodes

### DIFF
--- a/templates/vue/src/components/Lightbox/index.vue
+++ b/templates/vue/src/components/Lightbox/index.vue
@@ -272,7 +272,10 @@ export default {
       }
     },
     updateDimensions(dimensions) {
-      if (dimensions.height <= this.lightboxDimensions.height) {
+      if (
+        dimensions.height > 0 &&
+        dimensions.height <= this.lightboxDimensions.height
+      ) {
         this.dimensions = {
           ...this.dimensions,
           ...dimensions,

--- a/templates/vue/src/components/Lightbox/media/H5PMedia.vue
+++ b/templates/vue/src/components/Lightbox/media/H5PMedia.vue
@@ -113,23 +113,32 @@ export default {
         return
       }
 
-      this.frameHeight = this.$refs.h5p.contentWindow.document.activeElement.children[0].clientHeight
-      this.$emit("change:dimensions", { height: this.frameHeight })
+      const h5pDocument = this.$refs.h5p.contentWindow.document
+      const h5pContent =
+        h5pDocument.querySelector(".h5p-content") ??
+        h5pDocument.activeElement.children[0]
+      const h5pContentHeight = h5pContent.clientHeight
+      if (h5pContentHeight > 0) {
+        this.frameHeight = h5pContentHeight
+        this.$emit("change:dimensions", { height: this.frameHeight })
+      }
 
       // Watch for changes in the body of the iframe and update dimensions to match that
-      const h5pBodyContent = this.$refs.h5p.contentWindow.document.body.children[0]
       let that = this
       let heightChangeTimeout
       var ro = new ResizeObserver(entries => {
         for (let entry of entries) {
-          clearTimeout(heightChangeTimeout)
-          that.frameHeight = entry.contentRect.height
-          heightChangeTimeout = setTimeout(() => {
-            this.$emit("change:dimensions", { height: that.frameHeight })
-          }, 1000)
+          const height = entry.contentRect.height
+          if (height > 0) {
+            clearTimeout(heightChangeTimeout)
+            that.frameHeight = height
+            heightChangeTimeout = setTimeout(() => {
+              this.$emit("change:dimensions", { height: that.frameHeight })
+            }, 1000)
+          }
         }
       })
-      ro.observe(h5pBodyContent)
+      ro.observe(h5pContent)
 
       switch (this.library) {
         case "H5P.ThreeImage":

--- a/templates/vue/src/components/Sidebar/index.vue
+++ b/templates/vue/src/components/Sidebar/index.vue
@@ -257,8 +257,9 @@ export default {
             el = el.$el
           }
           if (el) {
-            console.error("Cannot scroll to non-existing element ", el)
             this.$refs.content.scroll(0, el.offsetTop - PADDING_OFFSET)
+          } else {
+            console.error("Cannot scroll to non-existing element ", el)
           }
         })
       }


### PR DESCRIPTION
## Changes
* Adjust the h5p height detection algorithm to look for the `.h5p-content` element (while still falling back to the previous behaviour of first element in the iframe body when the `.h5p-content` element is not found)
* Add a guard so that lightbox dimensions will only be set if not trying to set the height to 0.
* Additional bug fix: `console.error("Cannot scroll to non-existing element ", el)` was placed in the wrong conditional, causing the error to be printed to console every time the sidebar is opened.

## Screenshot
N/A
## Issue Linkage
Closes #1228 
## PR Dependency
Depends on: N/A
## Automated Testing
N/A