### PR TITLE
1261 - Bug fix: Import changelog is still shown when there is an error

### DIFF
--- a/templates/vue/src/components/TapestryMain/RootNodeButton/index.vue
+++ b/templates/vue/src/components/TapestryMain/RootNodeButton/index.vue
@@ -127,9 +127,11 @@ export default {
         client
           .importTapestry(upload)
           .then(response => {
-            this.changes.permissions = new Set(response.changes.permissions)
-            this.changes.noChange = response.changes.noChange
-            this.$bvModal.show("import-changelog")
+            if (response) {
+              this.changes.permissions = new Set(response.changes.permissions)
+              this.changes.noChange = response.changes.noChange
+              this.$bvModal.show("import-changelog")
+            }
           }) // TODO: Change this so a refresh isn't required
           .catch(err => {
             this.error = err
@@ -146,12 +148,16 @@ export default {
       client
         .importTapestryFromZip(zipFile)
         .then(response => {
-          this.changes.permissions = new Set(response.changes.permissions)
-          this.changes.noChange = response.changes.noChange
-          this.warnings = response.warnings
-          this.exportWarnings = response.exportWarnings
+          if (response) {
+            this.changes.permissions = new Set(response.changes.permissions)
+            this.changes.noChange = response.changes.noChange
+            this.warnings = response.warnings
+            this.exportWarnings = response.exportWarnings
 
-          return response.rebuildH5PCache
+            return response.rebuildH5PCache
+          } else {
+            return false
+          }
         })
         .catch(err => {
           this.error = err.response.data
@@ -163,11 +169,13 @@ export default {
             return WordpressApi.rebuildAllH5PCache()
           }
         })
-        .then(() => {
-          this.$bvModal.show("import-changelog")
-        })
         .catch(err => {
           this.error = err
+        })
+        .then(() => {
+          if (!this.error) {
+            this.$bvModal.show("import-changelog")
+          }
         })
         .finally(() => {
           this.isImporting = false


### PR DESCRIPTION
## Changes
* Add guards so the import changelog modal is not shown when there is an error, in the RootNodeButton component.
## Screenshot
N/A
## Issue Linkage
Closes #1261 
## PR Dependency
Depends on: N/A
