### PR TITLE
1258 - Improve permission checks in the backend

### DIFF
--- a/classes/class.constants.php
+++ b/classes/class.constants.php
@@ -21,3 +21,11 @@ class ReviewCommentTypes
     public const COMMENT = 'Comment';
     public const STATUS_CHANGE = 'StatusChange';
 }
+
+class UserActions
+{
+    public const READ = 'read';
+    public const ADD = 'add';
+    public const EDIT = 'edit';
+    public const MOVE = 'move';
+}

--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -8,7 +8,6 @@ require_once dirname(__FILE__).'/../classes/class.tapestry-user-progress.php';
 require_once dirname(__FILE__).'/../classes/class.tapestry-h5p.php';
 require_once dirname(__FILE__).'/../classes/class.constants.php';
 require_once dirname(__FILE__).'/../interfaces/interface.tapestry.php';
-require_once dirname(__FILE__).'/class.constants.php';
 
 /**
  * TODO: Implement group functionality. Currently all the group-related
@@ -825,8 +824,8 @@ class Tapestry implements ITapestry
 
     private function _userIsAllowed($node, $superuser_override, $userId)
     {
-        return TapestryHelpers::userIsAllowed('READ', $node, $this->postId, $superuser_override, $userId)
-        || TapestryHelpers::userIsAllowed('ADD', $node, $this->postId, $superuser_override, $userId)
-        || TapestryHelpers::userIsAllowed('EDIT', $node, $this->postId, $superuser_override, $userId);
+        return TapestryHelpers::userIsAllowed(UserActions::READ, $node, $this->postId, $superuser_override, $userId)
+        || TapestryHelpers::userIsAllowed(UserActions::ADD, $node, $this->postId, $superuser_override, $userId)
+        || TapestryHelpers::userIsAllowed(UserActions::EDIT, $node, $this->postId, $superuser_override, $userId);
     }
 }

--- a/endpoints.php
+++ b/endpoints.php
@@ -742,7 +742,12 @@ function deleteTapestry($request)
 function addTapestryNode($request)
 {
     $postId = $request['tapestryPostId'];
-    $node = json_decode($request->get_body());
+    $payload = json_decode($request->get_body());
+    $node = $payload->node;
+    $parentId = null;
+    if (isset($payload->parentId) && $payload->parentId !== null && $payload->parentId !== 0) {
+        $parentId = $payload->parentId;
+    }
     // TODO: JSON validations should happen here
     // make sure that we can only accept one node object at a time
     // adding multiple nodes would require multiple requests from the client
@@ -752,14 +757,43 @@ function addTapestryNode($request)
         }
         $tapestry = new Tapestry($postId);
 
-        if ($tapestry->isEmpty()) {
+        // Permission checks
+        if (!is_user_logged_in()) {
+            // Prevent guests from adding a node
+            throw new TapestryError('ADD_NODE_PERMISSION_DENIED', 'Please log in to add a node.');
+        }
+        if ($node->status !== NodeStatus::DRAFT) {
             $user = new TapestryUser();
-            if (!$user->canEdit($postId)) {
+
+            if (!TapestryHelpers::userIsAllowed(UserActions::ADD, $parentId, $postId)) {
                 throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
+            }
+
+            // Add user-specific permissions to the author (only do this if it is not a draft node)
+            $userId = $user->getID();
+            $node->permissions->{'user-'.$userId} = ['read', 'add', 'edit'];
+        } else {
+            $settings = $tapestry->getSettings();
+            if (!$settings->draftNodesEnabled) {
+                throw new TapestryError('DRAFT_NODES_DISABLED', 'Draft nodes are disabled for this Tapestry.', 403);
+            }
+            if (!$settings->submitNodesEnabled && isset($node->reviewStatus) && !empty($node->reviewStatus)) {
+                throw new TapestryError('DRAFT_NODES_DISABLED', 'You cannot submit draft nodes for this Tapestry.', 403);
             }
         }
 
-        return $tapestry->addNode($node);
+        $newNode = $tapestry->addNode($node, $parentId);
+        $result = (object) [
+            'node' => $newNode,
+        ];
+        if ($parentId) {
+            $result->link = $tapestry->addLink((object) [
+                'source' => $parentId,
+                'target' => $newNode->id,
+                'addedOnNodeCreation' => true,
+            ]);
+        }
+        return $result;
     } catch (TapestryError $e) {
         return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
     }
@@ -945,11 +979,10 @@ function addTapestryLink($request)
             $tapestry = new Tapestry($postId);
             return $tapestry->addLink($link);
         }
-        if (!TapestryHelpers::userIsAllowed('ADD', $link->source, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::ADD, $link->source, $postId)) {
             throw new TapestryError('ADD_LINK_PERMISSION_DENIED');
         }
-        if (!TapestryHelpers::userIsAllowed('ADD', $link->target, $postId)
-            && (!isset($link->addedOnNodeCreation) || !$link->addedOnNodeCreation)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::ADD, $link->target, $postId)) {
             throw new TapestryError('ADD_LINK_PERMISSION_DENIED');
         }
         $tapestry = new Tapestry($postId);
@@ -980,8 +1013,8 @@ function reverseTapestryLink($request)
         if ($postId && !TapestryHelpers::isValidTapestry($postId)) {
             throw new TapestryError('INVALID_POST_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('ADD', $newLink->source, $postId)
-            || !TapestryHelpers::userIsAllowed('ADD', $newLink->target, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::ADD, $newLink->source, $postId)
+            || !TapestryHelpers::userIsAllowed(UserActions::ADD, $newLink->target, $postId)) {
             throw new TapestryError('ADD_LINK_PERMISSION_DENIED');
         }
         $tapestry = new Tapestry($postId);
@@ -1007,10 +1040,10 @@ function deleteTapestryLink($request)
             throw new TapestryError('INVALID_POST_ID');
         }
         if (!TapestryHelpers::nodeIsDraft($link->target, $postId) && !TapestryHelpers::nodeIsDraft($link->source, $postId)) {
-            if (!TapestryHelpers::userIsAllowed('ADD', $link->source, $postId)) {
+            if (!TapestryHelpers::userIsAllowed(UserActions::ADD, $link->source, $postId)) {
                 throw new TapestryError('DELETE_LINK_PERMISSION_DENIED');
             }
-            if (!TapestryHelpers::userIsAllowed('ADD', $link->target, $postId)) {
+            if (!TapestryHelpers::userIsAllowed(UserActions::ADD, $link->target, $postId)) {
                 throw new TapestryError('DELETE_LINK_PERMISSION_DENIED');
             }
         }
@@ -1115,7 +1148,7 @@ function updateTapestryNode($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::EDIT, $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -1158,7 +1191,7 @@ function deleteTapestryNode($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::EDIT, $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -1194,7 +1227,7 @@ function updateTapestryNodeSize($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::EDIT, $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -1233,7 +1266,7 @@ function updateTapestryNodeDescription($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::EDIT, $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -1272,7 +1305,7 @@ function updateTapestryNodeTitle($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::EDIT, $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -1311,7 +1344,7 @@ function updateTapestryNodeImageURL($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::EDIT, $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -1350,7 +1383,7 @@ function updateTapestryNodeLockedImageURL($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::EDIT, $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -1426,7 +1459,7 @@ function updateTapestryNodeTypeData($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::EDIT, $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -1465,8 +1498,8 @@ function updateTapestryNodeCoordinates($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId) &&
-            !TapestryHelpers::userIsAllowed('MOVE', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::EDIT, $nodeMetaId, $postId) &&
+            !TapestryHelpers::userIsAllowed(UserActions::MOVE, $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -1499,7 +1532,7 @@ function getTapestryNodeHasDraftChildren($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::EDIT, $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -1852,7 +1885,7 @@ function getQuestionHasAnswers($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed(UserActions::EDIT, $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
 

--- a/templates/vue/cypress/support/commands.js
+++ b/templates/vue/cypress/support/commands.js
@@ -59,17 +59,14 @@ Cypress.Commands.add("getSelectedNode", () =>
     .then(({ nodes, selectedNodeId }) => nodes[selectedNodeId])
 )
 
-Cypress.Commands.add("addNode", { prevSubject: false }, (parent, node) => {
+Cypress.Commands.add("addNode", { prevSubject: false }, (parentId, node) => {
   cy.intercept("POST", `**/nodes`).as("addNode")
   cy.store().then(store => {
-    store.dispatch("addNode", deepMerge(store.getters.createDefaultNode(), node))
-    cy.wait("@addNode")
-    cy.getNodeByTitle(node.title).then(({ id }) => {
-      store.commit("updateVisibleNodes", [...store.state.visibleNodes, id])
-      if (parent) {
-        cy.addLink(parent.id || parent, id)
-      }
+    store.dispatch("addNode", {
+      node: deepMerge(store.getters.createDefaultNode(), node),
+      parentId,
     })
+    cy.wait("@addNode")
   })
 })
 

--- a/templates/vue/src/components/modals/NodeModal/forms/ContentForm/common/SubItemTable.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/ContentForm/common/SubItemTable.vue
@@ -13,7 +13,12 @@
               {{ subItemNode.title }}
             </b-td>
             <b-td class="text-right">
-              <b-link @click="handleEdit(subItemNode.id)">Edit</b-link>
+              <b-link
+                v-if="canEdit(subItemNode)"
+                @click="handleEdit(subItemNode.id)"
+              >
+                Edit
+              </b-link>
             </b-td>
           </b-tr>
         </b-tbody>
@@ -50,6 +55,7 @@
 <script>
 import { mapGetters, mapState } from "vuex"
 import { names } from "@/config/routes"
+import Helpers from "@/utils/Helpers"
 
 export default {
   name: "sub-item-table",
@@ -67,6 +73,7 @@ export default {
   computed: {
     ...mapState({
       node: "currentEditingNode",
+      showRejected: state => state.settings.showRejected,
     }),
     ...mapGetters(["getNode", "getDirectChildren"]),
     requiresSaving() {
@@ -84,6 +91,9 @@ export default {
     },
   },
   methods: {
+    canEdit(node) {
+      return Helpers.hasPermission(node, "edit", this.showRejected)
+    },
     addSubitem() {
       let newQuery = { ...this.$route.query, nav: "modal" }
       if (this.isPopups) {

--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -336,10 +336,11 @@ export default {
     ...mapState({
       node: "currentEditingNode",
     }),
+    parentId() {
+      return this.type === "add" ? this.nodeId : this.getParent(this.nodeId)
+    },
     parent() {
-      const parent = this.getNode(
-        this.type === "add" ? this.nodeId : this.getParent(this.nodeId)
-      )
+      const parent = this.getNode(this.parentId)
       return parent ? parent : null
     },
     title() {

--- a/templates/vue/src/services/TapestryAPI.js
+++ b/templates/vue/src/services/TapestryAPI.js
@@ -98,9 +98,9 @@ class TapestryApi {
    *
    * @return  {Object}
    */
-  async addNode(node) {
+  async addNode(payload) {
     const url = `/tapestries/${this.postId}/nodes`
-    const response = await this.client.post(url, node)
+    const response = await this.client.post(url, payload)
     return response
   }
 

--- a/templates/vue/src/store/getters.js
+++ b/templates/vue/src/store/getters.js
@@ -1,4 +1,5 @@
 import Helpers from "@/utils/Helpers"
+import * as wp from "../services/wp"
 
 export function getDirectChildren(state) {
   return id => {
@@ -86,7 +87,10 @@ export function isVisible(state, { getNode, hasMultiContentAncestor }) {
     if (!Helpers.hasPermission(node, "read", showRejected)) {
       return false
     }
-    if (!Helpers.hasPermission(node, "edit", showRejected)) {
+    if (
+      !Helpers.hasPermission(node, "edit", showRejected) &&
+      !wp.canEditTapestry()
+    ) {
       return (
         (node.unlocked || !node.hideWhenLocked) &&
         (showChildrenOfMulticontent || !hasMultiContentAncestor(node.id))

--- a/templates/vue/src/utils/Helpers.js
+++ b/templates/vue/src/utils/Helpers.js
@@ -201,7 +201,7 @@ export default class Helpers {
   static hasPermission(node, action, showRejected) {
     // Check 0: node is null case - this should only apply to creating the root node.
     if (node === null) {
-      return wp.canEditTapestry()
+      return action === userActions.ADD && wp.canEditTapestry()
     }
 
     // Public users never have any permissions other than read

--- a/templates/vue/src/utils/constants.js
+++ b/templates/vue/src/utils/constants.js
@@ -41,6 +41,7 @@ export const userActions = {
   READ: "read",
   ADD: "add",
   EDIT: "edit",
+  MOVE: "move",
 }
 
 export const DEFAULT_DEPTH = 3

--- a/utilities/class.tapestry-helpers.php
+++ b/utilities/class.tapestry-helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(__FILE__).'/class.tapestry-node-permissions.php';
+require_once dirname(__FILE__).'/../classes/class.constants.php';
 
 /**
  * Tapestry Helper Functions.
@@ -212,6 +212,7 @@ class TapestryHelpers
 
     /**
      * Check if the current user is allowed to an action to a node.
+     * The checks are similar to the Helpers.hasPermission checks in the frontend.
      *
      * @param string $action         action to be performed
      * @param Number $nodeMetaId     node meta ID
@@ -221,68 +222,130 @@ class TapestryHelpers
      */
     public static function userIsAllowed($action, $nodeMetaId, $tapestryPostId, $superuser_override = true, $_userId = null)
     {
-        $options = TapestryNodePermissions::getNodePermissions();
-        $nodePostId = get_metadata_by_mid('post', $nodeMetaId)->meta_value->post_id;
-
-        $tapestry = new Tapestry($tapestryPostId);
-        $node = $tapestry->getNode($nodeMetaId);
+        // Section 1: Fetching of information & special cases
 
         $userId = $_userId;
         if (is_null($userId)) {
             $userId = wp_get_current_user()->ID;
         }
-        $groupIds = self::getGroupIdsOfUser($userId, $tapestryPostId);
-        $user = new TapestryUser($userId);
 
-        // If node is submitted or accepted, users without edit access cannot edit node
-        $isEditableReviewStatus = isset($node->reviewStatus) && ($node->reviewStatus === "submitted" || $node->reviewStatus === "accepted");
-        if ($action === "EDIT" && $isEditableReviewStatus && !$user->canEdit($tapestryPostId)) {
+        // Guests never have any permissions other than read
+        if ($userId === 0 && $action !== UserActions::READ) {
             return false;
         }
 
+        $user = new TapestryUser($userId);
+        $canEditTapestry = $user->canEdit($tapestryPostId);
+
+        // Standalone nodes - only admins can publish
+        if ($nodeMetaId === null) {
+            return $action === UserActions::ADD && $canEditTapestry;
+        }
+
+        // Fetch information required by subsequent checks
+        $nodePostId = get_metadata_by_mid('post', $nodeMetaId)->meta_value->post_id;
+
+        $tapestry = new Tapestry($tapestryPostId);
+        $node = $tapestry->getNode($nodeMetaId);
+        $nodeMeta = $node->getMeta();
+
+        $groupIds = self::getGroupIdsOfUser($userId, $tapestryPostId);
+
+        // Section 2: Checks related to draft nodes
+
+        /**
+         * If node is a draft (accepted draft nodes are PUBLISHED nodes, so they are not considered here):
+         * - If node is not submitted for review:
+         *  - Allow all actions except "add" for original author
+         *  - Allow all actions except "edit" for reviewer if node is rejected and showRejected is true
+         * - If node is submitted for review:
+         *  - Only allow "read" for original author
+         *  - Allow all actions except "edit" for reviewer
+         */
+        if ($nodeMeta->status === NodeStatus::DRAFT) {
+            if ($user->isAuthorOfThePost($nodePostId)) {
+                if ($action === UserActions::READ || $canEditTapestry) {
+                    return true;
+                }
+                return $nodeMeta->reviewStatus !== NodeStatus::SUBMIT && $action !== UserActions::ADD;
+            }
+            if ($canEditTapestry) {
+                if ($action === UserActions::EDIT) {
+                    return false;
+                }
+                return $nodeMeta->reviewStatus === NodeStatus::SUBMIT || $nodeMeta->reviewStatus === NodeStatus::REJECT;
+            }
+            return false;
+        }
+
+        // Section 3: Override for admins / authors
+
+        // User has edit permissions for Tapestry
         if ($user->canEdit($tapestryPostId) && $superuser_override) {
             return true;
-        } elseif ($user->isAuthorOfThePost($nodePostId) && $node->getMeta()->status === "draft" && $node->getMeta()->reviewStatus !== "submitted") {
+        }
+
+        // User is the author of the node (unless node was submitted, then accepted)
+        if ($user->isAuthorOfThePost($nodePostId) && $nodeMeta->reviewStatus !== NodeStatus::ACCEPT) {
             return true;
-        } elseif ($user->isAuthorOfThePost($nodePostId) && $node->getMeta()->reviewStatus === "submitted" && $action === 'MOVE') {
+        }
+
+        // Section 4: Node-specific permissions
+
+        $nodePermissions = get_metadata_by_mid('post', $nodeMetaId)->meta_value->permissions;
+
+        // User has a permission associated with its ID
+        if (
+            property_exists($nodePermissions, 'user-'.$userId) &&
+            in_array($action, $nodePermissions->{'user-'.$userId})
+        ) {
             return true;
-        } else {
-            $nodePermissions = get_metadata_by_mid('post', $nodeMetaId)->meta_value->permissions;
+        }
+
+        // Node has public permissions
+        if (
+            property_exists($nodePermissions, 'public') &&
+            in_array($action, $nodePermissions->public)
+        ) {
+            return true;
+        }
+
+        // Node has authenticated permissions
+        if (
+            is_user_logged_in() &&
+            property_exists($nodePermissions, 'authenticated') &&
+            in_array($action, $nodePermissions->authenticated)
+        ) {
+            return true;
+        }
+
+        // User has a role that is allowed in the node
+        if (is_user_logged_in()) {
+            $roles = wp_get_current_user()->roles;
+            $allowedRoles = ['administrator', 'editor', 'author'];
+            foreach ($roles as $role) {
+                // Node has role-specific permissions
+                if (
+                    property_exists($nodePermissions, $role) &&
+                    in_array($action, $nodePermissions->$role)
+                ) {
+                    return true;
+                }
+                // The role has general edit permissions
+                if (in_array($role, $allowedRoles)) {
+                    return true;
+                }
+            }
+        }
+
+        // User is in a group that is allowed in the node
+        // ! This check is not implemented in the frontend
+        foreach ($groupIds as $groupId) {
             if (
-                property_exists($nodePermissions, 'user-'.$userId) &&
-                in_array($options[$action], $nodePermissions->{'user-'.$userId})
+                (property_exists($nodePermissions, 'group-'.$groupId))
+                && (in_array($action, $nodePermissions->{'group-'.$groupId}))
             ) {
                 return true;
-            } elseif (
-                property_exists($nodePermissions, 'public') &&
-                in_array($options[$action], $nodePermissions->public)
-            ) {
-                return true;
-            } elseif (
-                is_user_logged_in() &&
-                property_exists($nodePermissions, 'authenticated') &&
-                in_array($options[$action], $nodePermissions->authenticated)
-            ) {
-                return true;
-            } elseif (is_user_logged_in()) {
-                $roles = wp_get_current_user()->roles;
-                foreach ($roles as $role) {
-                    if (
-                        property_exists($nodePermissions, $role) &&
-                        in_array($options[$action], $nodePermissions->$role)
-                    ) {
-                        return true;
-                    }
-                }
-            } else {
-                foreach ($groupIds as $groupId) {
-                    if (
-                        (property_exists($nodePermissions, 'group-'.$groupId))
-                        && (in_array($options[$action], $nodePermissions->{'group-'.$groupId}))
-                    ) {
-                        return true;
-                    }
-                }
             }
         }
 

--- a/utilities/class.tapestry-node-permissions.php
+++ b/utilities/class.tapestry-node-permissions.php
@@ -38,21 +38,4 @@ class TapestryNodePermissions
 
         return $defaultPermissions;
     }
-
-    /**
-     * Get All Node Permission Options.
-     *
-     * @return array NodePermission
-     */
-    public static function getNodePermissions()
-    {
-        return [
-            'ADD' => 'add',
-            'READ' => 'read',
-            'EDIT' => 'edit',
-            'APPROVE' => 'approve',
-            'EDIT_SUBMIT' => 'edit_submit',
-            'ADD_SUBMIT' => 'add_submit',
-        ];
-    }
 }


### PR DESCRIPTION
## Changes
* Modify checks in `TapestryHelpers::userIsAllowed` (backend) to align with `Helper.hasPermission` (frontend).
* Change the action names used for node permission checks to lower case to match the frontend action names.
* Introduce `UserActions` constant class for backend which is a replica of the `userActions` constant in the frontend.
* Add "move" to the list of user actions.
* Fix a bug where admins cannot directly publish child nodes to a rejected node due to not passing `showRejected` value in the calls to `Helpers.hasPermission` in node modal.
* When adding a child node, the frontend now only calls the addNode endpoint instead of both the addNode and addLink endpoints; the addNode endpoint in the backend now takes care of adding the link from parent to child as well as doing some permission checks before adding the child node.
* No longer conditionally update childOrdering of parent node when adding a child node. The childOrdering of parent node is always updated when adding a child node.
* Always show multi-content child nodes and hidden nodes to the admin, even when the admin does not have edit permission on those nodes (this can happen for draft nodes submitted by other users).
* Hide the "edit" button in the SubItemTable used for showing video popups and multi-content child nodes when the user does not have edit permission (it's much better to hide the button instead of alert the user that they do not have edit permission when they click on the button) (again, this can happen for draft nodes submitted by other users). See screenshot below for an example.

## Screenshots

The "Edit" button will not show up when the user has no edit permission on that subitem (this applies to a draft node submitted by other users, such as the "Draft A" and "Draft A Private" nodes in the screenshot):

<img width="789" alt="image" src="https://user-images.githubusercontent.com/12668055/193184679-85776fe6-182f-4490-b30e-05ba3472b651.png">

## Issue Linkage
Closes #1258 
## PR Dependency
Depends on: N/A
