### PR TITLE
1308 - Remove extra margin in tapestry embeds

### DIFF
--- a/templates/header-iframe.php
+++ b/templates/header-iframe.php
@@ -11,6 +11,9 @@
         #tapestry-sidebar-container {
             display: none !important;
         }
+        html {
+            margin-top: 0 !important;
+        }
     </style>
 </head>
 <body <?php body_class(); ?>>


### PR DESCRIPTION
## Changes
* Removes the extra margin created by Wordpress for the admin bar space when in iframe mode.
## Issue Linkage
Closes #1308 
## PR Dependency
Depends on: N/A
## Automated Testing
* N/A
