### PR TITLE
1312 - Hide navigation buttons in multi-content unit child instead of disabling them

### DIFF
--- a/templates/vue/src/components/Lightbox/media/MultiContentMedia/index.vue
+++ b/templates/vue/src/components/Lightbox/media/MultiContentMedia/index.vue
@@ -38,12 +38,19 @@
             @complete="complete"
           />
           <div v-if="isUnitChild && pageIndex !== -1" class="unit-navigation">
-            <button :disabled="pageIndex === 0" @click="prevPage">
+            <button
+              :class="{
+                hidden: pageIndex === 0,
+              }"
+              @click="prevPage"
+            >
               <i class="fas fa-chevron-left" />
               <div>Previous</div>
             </button>
             <button
-              :disabled="pageIndex === filteredPages.length - 1"
+              :class="{
+                hidden: pageIndex === filteredPages.length - 1,
+              }"
               @click="nextPage"
             >
               <div>Next</div>
@@ -404,6 +411,10 @@ button[disabled] {
     height: 1rem;
     line-height: 1rem;
     color: #0073aa;
+
+    &.hidden {
+      visibility: hidden;
+    }
 
     &:not(:disabled):hover {
       color: var(--highlight-color);


### PR DESCRIPTION
## Changes
* Hide navigation buttons in multi-content unit child instead of disabling them when they're not available (i.e. on first page or last page).
## Screenshot
<img width="968" alt="image" src="https://user-images.githubusercontent.com/12668055/235525519-eab12724-4723-4fe1-af2d-4041e68d9df3.png">

## Issue Linkage
Closes #1312 
## PR Dependency
Depends on: N/A
## Automated Testing
* N/A
