### PR TITLE
1318 - Add Learning Objectives section in sidebar

### DIFF
--- a/templates/vue/src/components/modals/NodeModal/forms/ContentForm/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/ContentForm/index.vue
@@ -160,7 +160,7 @@ export default {
     ...mapGetters(["isMultiContentRow"]),
     shouldShowTitle: {
       get() {
-        return this.node.typeData.showTitle
+        return this.node.typeData.showTitle !== false
       },
       set(value) {
         this.update("typeData.showTitle", value)


### PR DESCRIPTION
## Changes
* Add node.learningObjectives property that stores the learning objectives the author set.
* Show the Learning Objectives information under the node description in the sidebar.
* Fix bug for the "show title in page" checkbox in the node modal that incorrectly displays as unchecked when the option is by default checked.
## Screenshot
* To be added.
## Issue Linkage
Closes #1318 
## PR Dependency
Depends on: N/A
## Automated Testing
* To be added.
