### PR TITLE
1322 - TYDE - Update twemoji picker CDN

### DIFF
--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/CommunityView/AddCommunityForm.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/CommunityView/AddCommunityForm.vue
@@ -20,6 +20,7 @@
           <div id="emoji-picker" style="position: relative">
             <twemoji-picker
               id="twemoji-picker"
+              twemojiPath="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/"
               :emojiData="emojiAllData"
               :emojiGroups="emojiGroups"
               :skinsSelection="true"

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/ConnectionsTab/AddConnectionForm.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/ConnectionsTab/AddConnectionForm.vue
@@ -25,6 +25,7 @@
         <div id="emoji-picker">
           <twemoji-picker
             id="twemoji-picker"
+            twemojiPath="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/"
             :emojiData="emojiDataAll"
             :emojiGroups="emojiGroups"
             :skinsSelection="true"


### PR DESCRIPTION
## Changes
* Update twemoji path for twemoji-picker component so the twemoji picker can render the emojis again.
## Screenshot
<img width="468" alt="image" src="https://github.com/tapestry-tool/tapestry-wp/assets/12668055/70a25f73-e08f-49a6-a1b4-3d1f831e635b">

## Issue Linkage
Closes #1322 
## PR Dependency
Depends on: branch tyde-with-kaltura-fixes
## Automated Testing
N/A
